### PR TITLE
Fix a bug causing main script to crash

### DIFF
--- a/main.py
+++ b/main.py
@@ -139,6 +139,7 @@ class DLresults():
         yerr = np.empty((2, y.shape[0]))
         yerr[0,:] = y-Rmin
         yerr[1,:] = Rmax-y
+        yerr = abs(yerr)  # getting rid of all negatives for the error bars due to rounding errors
         a, _ = self._fit()
         x_ref = np.array(range(int(x[-1]+1)))
         y_ref = a*np.array(x_ref)


### PR DESCRIPTION
**Bug found on 04/01/26:** 
- Code crashes during QA if the electrometer readings are the same for the same MU.

**Cause:**
- Crashes were caused by the error bars being negatives
- The negatives were caused by a float rounding error within python

**Fixes:**
- Added a line of code after all error bar calculation to ensure the error bar values are positive (i.e. absolute value)